### PR TITLE
Crash fix

### DIFF
--- a/waifu2x-metal/main.swift
+++ b/waifu2x-metal/main.swift
@@ -100,7 +100,10 @@ func createEmptyTexture(_ device: MTLDevice, width: Int, height: Int, format: MT
         desc.textureType = .type2DArray
         desc.arrayLength = length
     }
-
+    if #available(OSX 10.11, *) {
+        desc.usage = [.shaderWrite, .shaderRead]
+    }
+    
     return device.makeTexture(descriptor: desc)
 }
 

--- a/waifu2x-metal/main.swift
+++ b/waifu2x-metal/main.swift
@@ -263,7 +263,7 @@ func copy(_ src: [MTLTexture], dest: MTLTexture) {
 }
 
 if CommandLine.arguments.count >= 1 {
-    let path = "a.png"//Process.arguments[1]
+    let path = CommandLine.arguments[1]
 
     let resizeJsonFile = "scale2.0x_model.json"
     let jsonObj = try! JSONSerialization.jsonObject(with: Data(contentsOf: URL(fileURLWithPath: resizeJsonFile)), options: []) as! [[String: AnyObject]]


### PR DESCRIPTION
@safx I've got a crash on my machine:
```
/Library/Caches/com.apple.xbs/Sources/Metal/Metal-85.85/ToolsLayers/Debug/MTLDebugComputeCommandEncoder.mm:716: failed assertion `Function writes texture (outRGB[1]) whose usage (0x01) doesn't specify MTLTextureUsageShaderWrite 
```
This happens because since OS X 10.11 default value of `MTLTextureDescriptor` `usage` parameter is **shaderRead**. But in `main.swift` same textures used in **.shaderRead** and **.shaderWrite** context.
So, there is my fix.
By the way, I've also fixed input image argument.